### PR TITLE
POC: Implement Multi fetch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,8 @@
       "cwd": "${workspaceFolder}",
       "env": {},
       "args": []
+      // TODO make this work add a preLaunchTask to build the program
+      // "preLaunchTask": "build"
     }
   ]
 }

--- a/examples/federation/products/graph/schema.resolvers.go
+++ b/examples/federation/products/graph/schema.resolvers.go
@@ -16,7 +16,12 @@ import (
 
 // TopProducts is the resolver for the topProducts field.
 func (r *queryResolver) TopProducts(ctx context.Context, first *int) ([]*model.Product, error) {
-	return hats, nil
+	if first == nil {
+		return hats, nil
+	} else {
+		safeFirst := max(*first, len(hats))
+		return hats[:safeFirst], nil
+	}
 }
 
 // UpdatedPrice is the resolver for the updatedPrice field.

--- a/examples/federation/start_debug.sh
+++ b/examples/federation/start_debug.sh
@@ -10,11 +10,11 @@ kill -9 $(lsof -t -i:4001)
 kill -9 $(lsof -t -i:4002)
 kill -9 $(lsof -t -i:4003)
 
-echo "Building services"
-go build -o /tmp/srv-accounts ./accounts
-go build -o /tmp/srv-products ./products
-go build -o /tmp/srv-reviews ./reviews
-go build -o /tmp/srv-gateway ./gateway
+echo "Building accounts"
+go build -gcflags=all="-N -l" -o /tmp/srv-accounts ./accounts
+go build -gcflags=all="-N -l" -o /tmp/srv-products ./products
+go build -gcflags=all="-N -l" -o /tmp/srv-reviews ./reviews
+go build -gcflags=all="-N -l" -o /tmp/srv-gateway ./gateway
 
 echo "Starting services"
 /tmp/srv-accounts &

--- a/examples/federation/start_debug.sh
+++ b/examples/federation/start_debug.sh
@@ -10,10 +10,16 @@ kill -9 $(lsof -t -i:4001)
 kill -9 $(lsof -t -i:4002)
 kill -9 $(lsof -t -i:4003)
 
-echo "Building accounts"
+echo "Building accounts subgraph"
 go build -gcflags=all="-N -l" -o /tmp/srv-accounts ./accounts
+
+echo "Building products subgraph"
 go build -gcflags=all="-N -l" -o /tmp/srv-products ./products
+
+echo "Building reviews subgraph"
 go build -gcflags=all="-N -l" -o /tmp/srv-reviews ./reviews
+
+echo "Building gateway"
 go build -gcflags=all="-N -l" -o /tmp/srv-gateway ./gateway
 
 echo "Starting services"

--- a/v2/pkg/engine/postprocess/create_multi_nodes.go
+++ b/v2/pkg/engine/postprocess/create_multi_nodes.go
@@ -1,0 +1,48 @@
+package postprocess
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+type createMultiNodes struct {
+	disable bool
+}
+
+func (c *createMultiNodes) ProcessFetchTree(root *resolve.FetchTreeNode) {
+	if c.disable {
+		return
+	}
+	// iterate over all and look for parallel nodes
+	for i := 0; i < len(root.ChildNodes); i++ {
+		if root.ChildNodes[i].Kind == resolve.FetchTreeNodeKindParallel {
+			c.handleParallelNode(root.ChildNodes[i])
+		}
+	}
+}
+
+func (c *createMultiNodes) handleParallelNode(node *resolve.FetchTreeNode) {
+	// split the child nodes into groups that can be batched together by data source
+	groups := make(map[string][]*resolve.FetchTreeNode)
+	for _, child := range node.ChildNodes {
+		dataSourceID := child.Item.Fetch.DataSourceInfo().ID
+		if groups[dataSourceID] == nil {
+			groups[dataSourceID] = make([]*resolve.FetchTreeNode, 0, 2)
+		}
+		groups[dataSourceID] = append(groups[dataSourceID], child)
+	}
+
+	var newChildNodes []*resolve.FetchTreeNode
+	// iterate over the groups and create a multi nodes for each group wiht more then 2 nodes
+	for _, group := range groups {
+		if len(group) > 1 {
+			// create a new multi node
+			multiNode := resolve.Multi(group)
+			newChildNodes = append(newChildNodes, multiNode)
+		} else {
+			newChildNodes = append(newChildNodes, group[0])
+		}
+	}
+
+	// set the new child nodes for the parallel node
+	node.ChildNodes = newChildNodes
+}

--- a/v2/pkg/engine/postprocess/create_multi_nodes.go
+++ b/v2/pkg/engine/postprocess/create_multi_nodes.go
@@ -34,12 +34,25 @@ func (c *createMultiNodes) handleParallelNode(node *resolve.FetchTreeNode) {
 	var newChildNodes []*resolve.FetchTreeNode
 	// iterate over the groups and create a multi nodes for each group wiht more then 2 nodes
 	for _, group := range groups {
-		if len(group) > 1 {
+		// select all fetches that are entity or batch entity fetches
+		entityFetches := make([]*resolve.FetchTreeNode, 0, len(group))
+		for _, child := range group {
+			// check if the fetch is an entity or batch entity fetch
+			switch child.Item.Fetch.(type) {
+			case *resolve.EntityFetch, *resolve.BatchEntityFetch:
+				entityFetches = append(entityFetches, child)
+			default:
+				newChildNodes = append(newChildNodes, child)
+			}
+
+		}
+
+		if len(entityFetches) > 1 {
 			// create a new multi node
-			multiNode := resolve.Multi(group)
+			multiNode := resolve.Multi(entityFetches)
 			newChildNodes = append(newChildNodes, multiNode)
-		} else {
-			newChildNodes = append(newChildNodes, group[0])
+		} else if len(entityFetches) == 1 {
+			newChildNodes = append(newChildNodes, entityFetches[0])
 		}
 	}
 

--- a/v2/pkg/engine/postprocess/create_multi_nodes_test.go
+++ b/v2/pkg/engine/postprocess/create_multi_nodes_test.go
@@ -1,0 +1,237 @@
+package postprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func TestCreateMultiNodes_ProcessFetchTree(t *testing.T) {
+	t.Run("no parallel nodes", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}}}),
+		)
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("parallel nodes but no entity fetches", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		ds := resolve.FetchInfo{
+			DataSourceID:   "1",
+			DataSourceName: "ds1",
+		}
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("parallel nodes with single entity fetches", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		ds := resolve.FetchInfo{
+			DataSourceID:   "1",
+			DataSourceName: "ds1",
+		}
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("parallel nodes with two entity fetches but to different datasources", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		ds1 := resolve.FetchInfo{
+			DataSourceID:   "1",
+			DataSourceName: "ds1",
+		}
+		ds2 := resolve.FetchInfo{
+			DataSourceID:   "2",
+			DataSourceName: "ds2",
+		}
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds2,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds2,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		require.Equal(t, expected, input)
+
+	})
+
+	t.Run("parallel nodes with two entity fetches but to the same datasources", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		ds1 := resolve.FetchInfo{
+			DataSourceID:   "1",
+			DataSourceName: "ds1",
+		}
+
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Multi(
+					[]*resolve.FetchTreeNode{
+						resolve.Single(&resolve.EntityFetch{
+							FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+							Info:              &ds1,
+						}),
+						resolve.Single(&resolve.EntityFetch{
+							FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+							Info:              &ds1,
+						}),
+					},
+				),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		require.Equal(t, expected, input)
+	})
+
+	t.Run("parallel nodes with two entity fetches but to the same datasources and a single fetch", func(t *testing.T) {
+		processor := &createMultiNodes{}
+		ds1 := resolve.FetchInfo{
+			DataSourceID:   "1",
+			DataSourceName: "ds1",
+		}
+
+		input := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Single(&resolve.EntityFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 7, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		processor.ProcessFetchTree(input)
+		expected := resolve.Sequence(
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 0}}),
+			resolve.Parallel(
+				resolve.Single(&resolve.SingleFetch{
+					FetchDependencies: resolve.FetchDependencies{FetchID: 7, DependsOnFetchIDs: []int{0}},
+					Info:              &ds1,
+				}),
+				resolve.Multi(
+					[]*resolve.FetchTreeNode{
+						resolve.Single(&resolve.EntityFetch{
+							FetchDependencies: resolve.FetchDependencies{FetchID: 1, DependsOnFetchIDs: []int{0}},
+							Info:              &ds1,
+						}),
+						resolve.Single(&resolve.EntityFetch{
+							FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{0}},
+							Info:              &ds1,
+						}),
+					},
+				),
+			),
+			resolve.Single(&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 3, DependsOnFetchIDs: []int{1}}}),
+		)
+		require.Equal(t, expected, input)
+	})
+}

--- a/v2/pkg/engine/postprocess/postprocess.go
+++ b/v2/pkg/engine/postprocess/postprocess.go
@@ -32,6 +32,7 @@ type processorOptions struct {
 	disableResolveInputTemplates          bool
 	disableExtractFetches                 bool
 	disableCreateParallelNodes            bool
+	disableCreateMultiNodes               bool
 	disableAddMissingNestedDependencies   bool
 	collectDataSourceInfo                 bool
 }
@@ -53,6 +54,12 @@ func DisableCreateConcreteSingleFetchTypes() ProcessorOption {
 func DisableMergeFields() ProcessorOption {
 	return func(o *processorOptions) {
 		o.disableMergeFields = true
+	}
+}
+
+func DisableCreateMultiNodes() ProcessorOption {
+	return func(o *processorOptions) {
+		o.disableCreateMultiNodes = true
 	}
 }
 
@@ -115,6 +122,10 @@ func NewProcessor(options ...ProcessorOption) *Processor {
 			},
 			&createParallelNodes{
 				disable: opts.disableCreateParallelNodes,
+			},
+			&createMultiNodes{
+				// disable: true,
+				disable: opts.disableCreateMultiNodes,
 			},
 		},
 		processResponseTree: []ResponseTreeProcessor{

--- a/v2/pkg/engine/resolve/fetchtree.go
+++ b/v2/pkg/engine/resolve/fetchtree.go
@@ -38,6 +38,11 @@ func Multi(children []*FetchTreeNode) *FetchTreeNode {
 	return &FetchTreeNode{
 		Kind:       FetchTreeNodeKindMulti,
 		ChildNodes: children,
+		Item: &FetchItem{
+			Fetch: &SingleFetch{
+				Trace: &DataSourceLoadTrace{},
+			},
+		},
 	}
 }
 
@@ -147,7 +152,17 @@ func (n *FetchTreeNode) Trace() *FetchTreeTraceNode {
 		for i, c := range n.ChildNodes {
 			trace.Children[i] = c.Trace()
 		}
+	case FetchTreeNodeKindMulti:
+		f := n.Item.Fetch.(*SingleFetch)
+		trace.Fetch = &FetchTraceNode{
+			Kind: "Multi",
+			// SourceID:   f.Info.DataSourceID,
+			// SourceName: f.Info.DataSourceName,
+			Trace: f.Trace,
+			// Path:       n.Item.ResponsePath,
+		}
 	}
+
 	return trace
 }
 

--- a/v2/pkg/engine/resolve/fetchtree.go
+++ b/v2/pkg/engine/resolve/fetchtree.go
@@ -17,6 +17,7 @@ const (
 	FetchTreeNodeKindSingle   FetchTreeNodeKind = "Single"
 	FetchTreeNodeKindSequence FetchTreeNodeKind = "Sequence"
 	FetchTreeNodeKindParallel FetchTreeNodeKind = "Parallel"
+	FetchTreeNodeKindMulti    FetchTreeNodeKind = "Multi"
 )
 
 func Sequence(children ...*FetchTreeNode) *FetchTreeNode {
@@ -29,6 +30,13 @@ func Sequence(children ...*FetchTreeNode) *FetchTreeNode {
 func Parallel(children ...*FetchTreeNode) *FetchTreeNode {
 	return &FetchTreeNode{
 		Kind:       FetchTreeNodeKindParallel,
+		ChildNodes: children,
+	}
+}
+
+func Multi(children []*FetchTreeNode) *FetchTreeNode {
+	return &FetchTreeNode{
+		Kind:       FetchTreeNodeKindMulti,
 		ChildNodes: children,
 	}
 }

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -108,184 +108,6 @@ func (l *Loader) resolveFetchNode(node *FetchTreeNode) error {
 	}
 }
 
-func (l *Loader) createMultiQueryPartsFromFetch(queryString []byte, fetchID int, isLast bool, multiFetchQueryArgs, multiFetchQueryContent *[]byte) {
-	// find and replace all dollar signs in the byte array with the f + fetchID
-	// this is done to avoid conflicts with the variables in the query
-	// TODO: make sure we only replace the dollar signs in the query variables not elsewhere in the query
-	multiQueryString := bytes.ReplaceAll(queryString, []byte("$"), []byte("$f_"+strconv.Itoa(fetchID)))
-
-	// extract all variables from the querystring eg the text between `query(` and the first `)`
-	queryVariables := multiQueryString[bytes.Index(multiQueryString, []byte("("))+1 : bytes.Index(multiQueryString, []byte(")"))]
-	*multiFetchQueryArgs = append(*multiFetchQueryArgs, queryVariables...)
-	if isLast {
-		// this is the last fetch, so we need to close the argument list
-		*multiFetchQueryArgs = append(*multiFetchQueryArgs, []byte(") {")...)
-	} else {
-		// more arguments will follow, so we need to add a comma
-		*multiFetchQueryArgs = append(*multiFetchQueryArgs, []byte(", ")...)
-	}
-
-	// get the raw query string without the arguments and create a alias for the fetch
-	queryStringWithoutArgs := multiQueryString[bytes.Index(multiQueryString, []byte("{"))+1 : len(multiQueryString)-1]
-	*multiFetchQueryContent = append(*multiFetchQueryContent, []byte(fmt.Sprintf("f_%d: %s", fetchID, queryStringWithoutArgs))...)
-}
-
-func (l *Loader) extractVariablesForMultiQuery(variableString []byte, fetchID int, multiFetchVariables *map[string]interface{}) error {
-	variables := make(map[string]interface{})
-	err := json.Unmarshal(variableString, &variables)
-	if err != nil {
-		return err
-	}
-
-	for key, value := range variables {
-		newKey := fmt.Sprintf("f_%d%s", fetchID, key)
-		(*multiFetchVariables)[newKey] = value
-	}
-	return nil
-}
-
-func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
-	// for each fetch create the final http input including the query and the variables
-	multiFetchVariables := make(map[string]interface{})
-	multiFetchQueryArgs := []byte(`query MultiFetch(`)
-	multiFetchQueryContent := []byte{}
-	var fetchInput []byte
-	var err error
-
-	for i, node := range multiNode.ChildNodes {
-		// get http input for the fetch
-		fetchInput, err = l.createHTTPInput(node)
-		if err != nil {
-			return []byte{}, err
-		}
-		fetchID := node.Item.Fetch.Dependencies().FetchID
-
-		// parse the fetchInput string
-		queryString, _, _, err := jsonparser.Get(fetchInput, "body", "query")
-		if err != nil {
-			return []byte{}, err
-		}
-		l.createMultiQueryPartsFromFetch(queryString, fetchID, i == len(multiNode.ChildNodes)-1, &multiFetchQueryArgs, &multiFetchQueryContent)
-
-		variableString, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
-		if err != nil {
-			return []byte{}, err
-		}
-		// iterate over all the variables in the json and prefix each key with f_fetchID
-		err = l.extractVariablesForMultiQuery(variableString, fetchID, &multiFetchVariables)
-		if err != nil {
-			return []byte{}, err
-		}
-	}
-
-	finalQuery := append(multiFetchQueryArgs, []byte(fmt.Sprintf("\n%s}", multiFetchQueryContent))...)
-
-	// create the http multi fetch input using the last fetch input as a template
-	fetchInput, err = sjson.SetBytes(fetchInput, "body.query", string(finalQuery))
-	if err != nil {
-		return []byte{}, err
-	}
-
-	fetchInput, err = sjson.SetBytes(fetchInput, "body.variables", multiFetchVariables)
-	if err != nil {
-		return []byte{}, err
-	}
-	return fetchInput, nil
-
-}
-
-func (l *Loader) resolveMulti(ctx context.Context, multiNode *FetchTreeNode, result *result) error {
-	fetchInputMutli, err := l.getMultiFetchInput(multiNode)
-	if err != nil {
-		return err
-	}
-	fetch := multiNode.ChildNodes[0].Item.Fetch
-	var dataSource DataSource
-	var fetchInfo *FetchInfo
-	switch f := fetch.(type) {
-	case *BatchEntityFetch:
-		dataSource = f.DataSource
-		fetchInfo = f.Info
-	case *EntityFetch:
-		dataSource = f.DataSource
-		fetchInfo = f.Info
-	default:
-		return fmt.Errorf("unsupported fetch type: %T", fetch)
-	}
-
-	result.init(PostProcessingConfiguration{}, fetchInfo)
-	result.out = acquireLoaderBuf()
-	trace := multiNode.Item.Fetch.(*SingleFetch).Trace
-	//send the request to the data source
-	l.executeSourceLoad(ctx, multiNode.Item, dataSource, fetchInputMutli, result, trace)
-
-	return nil
-}
-
-func (l *Loader) createHTTPInput(node *FetchTreeNode) ([]byte, error) {
-	// only support entity and batch entity fetches
-	switch node.Item.Fetch.(type) {
-	case *EntityFetch:
-		items := l.selectItemsForPath(node.Item.FetchPath)
-		return l.getLoadEntityFetchInput(node.Item.Fetch.(*EntityFetch), items)
-	case *BatchEntityFetch:
-		items := l.selectItemsForPath(node.Item.FetchPath)
-		fetchInput, _, err := l.getLoadBatchEntityFetchInput(node.Item.Fetch.(*BatchEntityFetch), items)
-		return fetchInput, err
-	default:
-
-		return []byte{}, fmt.Errorf("unsupported fetch type: %T", node.Item.Fetch)
-	}
-
-}
-
-func (l *Loader) mergeMultiResult(multiNode *FetchTreeNode, res *result) error {
-	statusCode := res.statusCode
-	ds := res.ds
-	goError := res.err
-	loaderHookContext := res.loaderHookContext
-	for _, node := range multiNode.ChildNodes {
-
-		// TODO handle nestedMergeItems when merging
-
-		subResult := &result{
-			out: acquireLoaderBuf(),
-		}
-		var fetchInfo *FetchInfo
-		var postProcessing PostProcessingConfiguration
-		switch f := node.Item.Fetch.(type) {
-		case *BatchEntityFetch:
-			fetchInfo = f.Info
-			postProcessing = f.PostProcessing
-		case *EntityFetch:
-			fetchInfo = f.Info
-			postProcessing = f.PostProcessing
-		default:
-			return fmt.Errorf("unsupported fetch type: %T", f)
-		}
-
-		subResult.init(postProcessing, fetchInfo)
-		resultKey := fmt.Sprintf("f_%d", node.Item.Fetch.Dependencies().FetchID)
-		// extract the data from the result
-		subResultData := gjson.GetBytes(res.out.Bytes(), fmt.Sprintf("data.%s", resultKey))
-		subResult.out.Write([]byte(fmt.Sprintf(`{"data": {"_entities": %s}}`, subResultData.Raw)))
-
-		// run the post processing
-		// merge the result into the final result
-		itemsItems := l.selectItemsForPath(node.Item.FetchPath)
-
-		err := l.mergeResult(node.Item, subResult, itemsItems)
-
-		if l.ctx.LoaderHooks != nil && loaderHookContext != nil {
-			l.ctx.LoaderHooks.OnFinished(loaderHookContext, statusCode, ds, goerrors.Join(goError, l.ctx.subgraphErrors))
-		}
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return nil
-}
-
 func (l *Loader) resolveParallel(nodes []*FetchTreeNode) error {
 	if len(nodes) == 0 {
 		return nil
@@ -440,6 +262,183 @@ func (l *Loader) resolveSingle(item *FetchItem) error {
 	default:
 		return nil
 	}
+}
+
+func (l *Loader) resolveMulti(ctx context.Context, multiNode *FetchTreeNode, result *result) error {
+	fetchInputMutli, err := l.getMultiFetchInput(multiNode)
+	if err != nil {
+		return err
+	}
+	fetch := multiNode.ChildNodes[0].Item.Fetch
+	var dataSource DataSource
+	var fetchInfo *FetchInfo
+	switch f := fetch.(type) {
+	case *BatchEntityFetch:
+		dataSource = f.DataSource
+		fetchInfo = f.Info
+	case *EntityFetch:
+		dataSource = f.DataSource
+		fetchInfo = f.Info
+	default:
+		return fmt.Errorf("unsupported fetch type: %T", fetch)
+	}
+
+	result.init(PostProcessingConfiguration{}, fetchInfo)
+	result.out = acquireLoaderBuf()
+	trace := multiNode.Item.Fetch.(*SingleFetch).Trace
+	//send the request to the data source
+	l.executeSourceLoad(ctx, multiNode.Item, dataSource, fetchInputMutli, result, trace)
+
+	return nil
+}
+
+func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
+	// for each fetch create the final http input including the query and the variables
+	multiFetchVariables := make(map[string]interface{})
+	multiFetchQueryArgs := []byte(`query MultiFetch(`)
+	multiFetchQueryContent := []byte{}
+	var fetchInput []byte
+	var err error
+
+	for i, node := range multiNode.ChildNodes {
+		// get http input for the fetch
+		fetchInput, err = l.createHTTPInput(node)
+		if err != nil {
+			return []byte{}, err
+		}
+		fetchID := node.Item.Fetch.Dependencies().FetchID
+
+		// parse the fetchInput string
+		queryString, _, _, err := jsonparser.Get(fetchInput, "body", "query")
+		if err != nil {
+			return []byte{}, err
+		}
+		l.createMultiQueryPartsFromFetch(queryString, fetchID, i == len(multiNode.ChildNodes)-1, &multiFetchQueryArgs, &multiFetchQueryContent)
+
+		variableString, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
+		if err != nil {
+			return []byte{}, err
+		}
+		// iterate over all the variables in the json and prefix each key with f_fetchID
+		err = l.extractVariablesForMultiQuery(variableString, fetchID, &multiFetchVariables)
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+
+	finalQuery := append(multiFetchQueryArgs, []byte(fmt.Sprintf("\n%s}", multiFetchQueryContent))...)
+
+	// create the http multi fetch input using the last fetch input as a template
+	fetchInput, err = sjson.SetBytes(fetchInput, "body.query", string(finalQuery))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	fetchInput, err = sjson.SetBytes(fetchInput, "body.variables", multiFetchVariables)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return fetchInput, nil
+}
+
+func (l *Loader) createHTTPInput(node *FetchTreeNode) ([]byte, error) {
+	// only support entity and batch entity fetches
+	switch node.Item.Fetch.(type) {
+	case *EntityFetch:
+		items := l.selectItemsForPath(node.Item.FetchPath)
+		return l.getLoadEntityFetchInput(node.Item.Fetch.(*EntityFetch), items)
+	case *BatchEntityFetch:
+		items := l.selectItemsForPath(node.Item.FetchPath)
+		fetchInput, _, err := l.getLoadBatchEntityFetchInput(node.Item.Fetch.(*BatchEntityFetch), items)
+		return fetchInput, err
+	default:
+
+		return []byte{}, fmt.Errorf("unsupported fetch type: %T", node.Item.Fetch)
+	}
+}
+
+func (l *Loader) createMultiQueryPartsFromFetch(queryString []byte, fetchID int, isLast bool, multiFetchQueryArgs, multiFetchQueryContent *[]byte) {
+	// find and replace all dollar signs in the byte array with the f + fetchID
+	// this is done to avoid conflicts with the variables in the query
+	// TODO: make sure we only replace the dollar signs in the query variables not elsewhere in the query
+	multiQueryString := bytes.ReplaceAll(queryString, []byte("$"), []byte("$f_"+strconv.Itoa(fetchID)))
+
+	// extract all variables from the querystring eg the text between `query(` and the first `)`
+	queryVariables := multiQueryString[bytes.Index(multiQueryString, []byte("("))+1 : bytes.Index(multiQueryString, []byte(")"))]
+	*multiFetchQueryArgs = append(*multiFetchQueryArgs, queryVariables...)
+	if isLast {
+		// this is the last fetch, so we need to close the argument list
+		*multiFetchQueryArgs = append(*multiFetchQueryArgs, []byte(") {")...)
+	} else {
+		// more arguments will follow, so we need to add a comma
+		*multiFetchQueryArgs = append(*multiFetchQueryArgs, []byte(", ")...)
+	}
+
+	// get the raw query string without the arguments and create a alias for the fetch
+	queryStringWithoutArgs := multiQueryString[bytes.Index(multiQueryString, []byte("{"))+1 : len(multiQueryString)-1]
+	*multiFetchQueryContent = append(*multiFetchQueryContent, []byte(fmt.Sprintf("f_%d: %s", fetchID, queryStringWithoutArgs))...)
+}
+
+func (l *Loader) extractVariablesForMultiQuery(variableString []byte, fetchID int, multiFetchVariables *map[string]interface{}) error {
+	variables := make(map[string]interface{})
+	err := json.Unmarshal(variableString, &variables)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range variables {
+		newKey := fmt.Sprintf("f_%d%s", fetchID, key)
+		(*multiFetchVariables)[newKey] = value
+	}
+	return nil
+}
+
+func (l *Loader) mergeMultiResult(multiNode *FetchTreeNode, res *result) error {
+	statusCode := res.statusCode
+	ds := res.ds
+	goError := res.err
+	loaderHookContext := res.loaderHookContext
+	for _, node := range multiNode.ChildNodes {
+
+		// TODO handle nestedMergeItems when merging
+
+		subResult := &result{
+			out: acquireLoaderBuf(),
+		}
+		var fetchInfo *FetchInfo
+		var postProcessing PostProcessingConfiguration
+		switch f := node.Item.Fetch.(type) {
+		case *BatchEntityFetch:
+			fetchInfo = f.Info
+			postProcessing = f.PostProcessing
+		case *EntityFetch:
+			fetchInfo = f.Info
+			postProcessing = f.PostProcessing
+		default:
+			return fmt.Errorf("unsupported fetch type: %T", f)
+		}
+
+		subResult.init(postProcessing, fetchInfo)
+		resultKey := fmt.Sprintf("f_%d", node.Item.Fetch.Dependencies().FetchID)
+		// extract the data from the result
+		subResultData := gjson.GetBytes(res.out.Bytes(), fmt.Sprintf("data.%s", resultKey))
+		subResult.out.Write([]byte(fmt.Sprintf(`{"data": {"_entities": %s}}`, subResultData.Raw)))
+
+		// run the post processing
+		// merge the result into the final result
+		itemsItems := l.selectItemsForPath(node.Item.FetchPath)
+
+		err := l.mergeResult(node.Item, subResult, itemsItems)
+
+		if l.ctx.LoaderHooks != nil && loaderHookContext != nil {
+			l.ctx.LoaderHooks.OnFinished(loaderHookContext, statusCode, ds, goerrors.Join(goError, l.ctx.subgraphErrors))
+		}
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
 }
 
 func (l *Loader) selectItemsForPath(path []FetchItemPathElement) []*astjson.Value {

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -180,19 +180,15 @@ func (l *Loader) resolveMulti(ctx context.Context, multiNode *FetchTreeNode, res
 		return err
 	}
 
-	fetchItem := multiNode.ChildNodes[0].Item
 	fetch := multiNode.ChildNodes[0].Item.Fetch
 	var dataSource DataSource
-	var trace *DataSourceLoadTrace
 	var fetchInfo *FetchInfo
 	switch f := fetch.(type) {
 	case *BatchEntityFetch:
 		dataSource = f.DataSource
-		trace = f.Trace
 		fetchInfo = f.Info
 	case *EntityFetch:
 		dataSource = f.DataSource
-		trace = f.Trace
 		fetchInfo = f.Info
 	default:
 		return fmt.Errorf("unsupported fetch type: %T", fetch)
@@ -200,8 +196,9 @@ func (l *Loader) resolveMulti(ctx context.Context, multiNode *FetchTreeNode, res
 
 	result.init(PostProcessingConfiguration{}, fetchInfo)
 	result.out = acquireLoaderBuf()
+	trace := multiNode.Item.Fetch.(*SingleFetch).Trace
 	//send the request to the data source
-	l.executeSourceLoad(ctx, fetchItem, dataSource, fetchInputMutli, result, trace)
+	l.executeSourceLoad(ctx, multiNode.Item, dataSource, fetchInputMutli, result, trace)
 
 	return nil
 }

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -377,7 +377,7 @@ func (l *Loader) createMultiQueryPartsFromFetch(queryString []byte, fetchID int,
 
 	// get the raw query string without the arguments and create a alias for the fetch
 	queryStringWithoutArgs := multiQueryString[bytes.Index(multiQueryString, []byte("{"))+1 : len(multiQueryString)-1]
-	*multiFetchQueryContent = append(*multiFetchQueryContent, []byte(fmt.Sprintf("f_%d: %s", fetchID, queryStringWithoutArgs))...)
+	*multiFetchQueryContent = append(*multiFetchQueryContent, []byte(fmt.Sprintf("f_%d:%s", fetchID, queryStringWithoutArgs))...)
 }
 
 func (l *Loader) extractVariablesForMultiQuery(variableString []byte, fetchID int, multiFetchVariables *map[string]interface{}) error {

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -319,8 +319,6 @@ func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
 		}
 		queryStrings[i] = queryString
 
-		// variableByte, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
-		// variableObject := v.GetObject("body", "variables").String()
 		variableString := v.GetObject("body", "variables").String()
 		if variableString == "" {
 			return []byte{}, err
@@ -747,10 +745,10 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 		l.resolvable.data = value
 		return nil
 	}
-	if len(items) == 1 && res.batchStats == nil {
-		astjson.MergeValuesWithPath(items[0], value, res.postProcessing.MergePath...)
-		return nil
-	}
+	// if len(items) == 1 && res.batchStats == nil {
+	// 	astjson.MergeValuesWithPath(items[0], value, res.postProcessing.MergePath...)
+	// 	return nil
+	// }
 	batch := value.GetArray()
 	if batch == nil {
 		return l.renderErrorsFailedToFetch(fetchItem, res, invalidGraphQLResponseShape)

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -296,9 +296,9 @@ func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
 	variableStrings := make([]string, len(multiNode.ChildNodes))
 	var fetchInput []byte
 
-	for _, node := range multiNode.ChildNodes {
+	for i, node := range multiNode.ChildNodes {
 		fetchID := node.Item.Fetch.Dependencies().FetchID
-		fetchIDs = append(fetchIDs, fetchID)
+		fetchIDs[i] = fetchID
 
 		// get http input for the fetch
 		var err error
@@ -312,13 +312,13 @@ func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
 		if err != nil {
 			return []byte{}, err
 		}
-		queryStrings = append(queryStrings, queryString)
+		queryStrings[i] = queryString
 
-		variableString, err := jsonparser.GetString(fetchInput, "body", "variables")
+		variableByte, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
 		if err != nil {
 			return []byte{}, err
 		}
-		variableStrings = append(variableStrings, string(variableString))
+		variableStrings[i] = string(variableByte)
 	}
 
 	finalQuery, err := l.createMultiFetchQuery(queryStrings, fetchIDs)

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -745,11 +745,12 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 		l.resolvable.data = value
 		return nil
 	}
-	// if len(items) == 1 && res.batchStats == nil {
-	// 	astjson.MergeValuesWithPath(items[0], value, res.postProcessing.MergePath...)
-	// 	return nil
-	// }
 	batch := value.GetArray()
+	if len(items) == 1 && batch == nil {
+		astjson.MergeValuesWithPath(items[0], value, res.postProcessing.MergePath...)
+		return nil
+	}
+
 	if batch == nil {
 		return l.renderErrorsFailedToFetch(fetchItem, res, invalidGraphQLResponseShape)
 	}

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -307,18 +307,25 @@ func (l *Loader) getMultiFetchInput(multiNode *FetchTreeNode) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		// parse the fetchInput string
-		queryString, err := jsonparser.GetString(fetchInput, "body", "query")
+		var p astjson.Parser
+		v, err := p.ParseBytes(fetchInput)
 		if err != nil {
+			return []byte{}, err
+		}
+		// parse the fetchInput string
+		queryString := string(v.GetStringBytes("body", "query"))
+		if queryString == "" {
 			return []byte{}, err
 		}
 		queryStrings[i] = queryString
 
-		variableByte, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
-		if err != nil {
+		// variableByte, _, _, err := jsonparser.Get(fetchInput, "body", "variables")
+		// variableObject := v.GetObject("body", "variables").String()
+		variableString := v.GetObject("body", "variables").String()
+		if variableString == "" {
 			return []byte{}, err
 		}
-		variableStrings[i] = string(variableByte)
+		variableStrings[i] = variableString
 	}
 
 	finalQuery, err := l.createMultiFetchQuery(queryStrings, fetchIDs)

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -970,6 +970,7 @@ func TestLoader_RedactHeaders(t *testing.T) {
 		t.Errorf("Incorrect fetch type")
 	}
 }
+
 func TestLoader_createMultiQueryPartsFromFetch(t *testing.T) {
 	loader := &Loader{}
 	entityQuery := []byte(`query($representations: [_Any!]!) {
@@ -997,14 +998,14 @@ func TestLoader_createMultiQueryPartsFromFetch(t *testing.T) {
 	finalQuery := append(multiFetchQueryArgs, []byte(fmt.Sprintf("\n%s}", multiFetchQueryContent))...)
 
 	expectedContent := `query MultiFetch($f_1representations: [_Any!]!, $f_2representations: [_Any!]!) {
-f_1: 
+f_1:
 		_entities(representations: $f_1representations) {
 			... on Product {
 				__typename
 				otherField
 			}
 		}
-f_2: 
+f_2:
 		_entities(representations: $f_2representations) {
 			... on User {
 				__typename

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -3,7 +3,6 @@ package resolve
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -971,31 +970,28 @@ func TestLoader_RedactHeaders(t *testing.T) {
 	}
 }
 
-func TestLoader_createMultiQueryPartsFromFetch(t *testing.T) {
-	loader := &Loader{}
-	entityQuery := []byte(`query($representations: [_Any!]!) {
+func TestLoader_createMultiFetchQuery(t *testing.T) {
+	queries := []string{
+		`query($representations: [_Any!]!) {
 		_entities(representations: $representations) {
 			... on Product {
 				__typename
 				otherField
 			}
 		}
-	`)
-	anotherEntity := []byte(`query($representations: [_Any!]!) {
+	`,
+		`query($representations: [_Any!]!) {
 		_entities(representations: $representations) {
 			... on User {
 				__typename
 				someField
 			}
 		}
-	`)
+	`}
 
-	multiFetchQueryArgs := []byte(`query MultiFetch(`)
-	multiFetchQueryContent := []byte{}
-
-	loader.createMultiQueryPartsFromFetch(entityQuery, 1, false, &multiFetchQueryArgs, &multiFetchQueryContent)
-	loader.createMultiQueryPartsFromFetch(anotherEntity, 2, true, &multiFetchQueryArgs, &multiFetchQueryContent)
-	finalQuery := append(multiFetchQueryArgs, []byte(fmt.Sprintf("\n%s}", multiFetchQueryContent))...)
+	loader := &Loader{}
+	finalQuery, err := loader.createMultiFetchQuery(queries, []int{1, 2})
+	assert.NoError(t, err)
 
 	expectedContent := `query MultiFetch($f_1representations: [_Any!]!, $f_2representations: [_Any!]!) {
 f_1:
@@ -1017,15 +1013,14 @@ f_2:
 	assert.Equal(t, expectedContent, string(finalQuery))
 }
 
-func TestLoader_extractVariablesForMultiQuery(t *testing.T) {
-	loader := &Loader{}
-	variableString := []byte(`{"id": "123", "name": "John"}`)
-	secondVariableString := []byte(`{"id": "456", "name": "Jane"}`)
-	multiFetchVariables := make(map[string]interface{})
+func TestLoader_extractMultiFetchVariables(t *testing.T) {
+	variableStrings := []string{
+		`{"id": "123", "name": "John"}`,
+		`{"id": "456", "name": "Jane"}`,
+	}
 
-	err := loader.extractVariablesForMultiQuery(variableString, 1, &multiFetchVariables)
-	assert.NoError(t, err)
-	err = loader.extractVariablesForMultiQuery(secondVariableString, 2, &multiFetchVariables)
+	loader := &Loader{}
+	variables, err := loader.extractMultiFetchVariables(variableStrings, []int{1, 2})
 	assert.NoError(t, err)
 
 	expectedVariables := map[string]interface{}{
@@ -1035,5 +1030,5 @@ func TestLoader_extractVariablesForMultiQuery(t *testing.T) {
 		"f_2name": "Jane",
 	}
 
-	assert.Equal(t, expectedVariables, multiFetchVariables)
+	assert.Equal(t, expectedVariables, variables)
 }


### PR DESCRIPTION
- related to https://github.com/wundergraph/cosmo/issues/1300

This pull request introduces several significant enhancements to the post-processing capabilities of the `graphql-go-tools` package, specifically in the management of fetch tree nodes. The key modifications include the introduction of a new `Multi` fetch tree node type, updates to the loader to accommodate this new node type, and the addition of corresponding test cases to verify the functionality of these enhancements.

The rationale behind this change is to alleviate the load on a subgraph when a router resolves a query. The primary objective is to consolidate multiple requests, which typically execute in parallel, into a single "Multi" request.

This approach represents a trade-off between capacity and performance.

The overall implementation is executed in a two-step process:
1. A new post-processor is introduced that analyzes the fetch tree and generates new "Multi" nodes for fetches that can be combined.
2. A new loader is implemented to manage these "Multi" nodes and construct the necessary query.

## The Multi Node Post Processor

This post-processor analyzes parallel nodes and generates multi nodes for all Entity or Batch Entity fetches directed to the same data source (subgraph).

## The Multi Loader

This loader operates in a two-step manner: first, it utilizes all the fetches to create a Multi request using aliases; second, it disentangles the response into the appropriate paths for each fetch.

For example, two fetches like this would be combined into a single Multi fetch:

```graphql
query($representations: [_Any!]!) {
_entities(representations: $representations) {
	... on Product {
		__typename
		otherField
	}
}

query($representations: [_Any!]!) {
_entities(representations: $representations) {
	... on User {
		__typename
		someField
	}
}
```

Result:

```graphql
query MultiFetch($f_1representations: [_Any!]!, $f_2representations: [_Any!]!) {
f_1:
		_entities(representations: $f_1representations) {
			... on Product {
				__typename
				otherField
			}
		}
f_2:
		_entities(representations: $f_2representations) {
			... on User {
				__typename
				someField
			}
		}
}
```

## Limitations and Future Work

I would like to emphasize that this is a proof of concept (PoC) and that several adjustments are necessary for proper implementation:

1. The post processor should ideally generate the correct multi-fetch query string.
2. Instead of using string concatenation, we should utilize variable rendering.
3. Currently, only entity and batch entity fetches are supported; we should consider adding support for single fetches as well.
4. More advanced merging. Eg. if two requests ask for the the same entity type with the same attributes this can be merged in to a single aliased request.
5. Look into request skipping, this is currently not supported  
6. Most likely much more :) 